### PR TITLE
QA-13997 : fixed the query of the locked content report

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
   </parent>
   <groupId>org.jahia.modules</groupId>
   <artifactId>content-reports</artifactId>
-  <version>2.3.0-SNAPSHOT</version>
+  <version>2.2.1-SNAPSHOT</version>
   <packaging>bundle</packaging>
   <name>Content Reports</name>
   <description>This is the custom module (Content Reports) for running on a Digital Experience Manager server.</description>
@@ -66,7 +66,7 @@
   <properties>
     <jahia-depends>default,external-provider,siteSettings</jahia-depends>
     <require-capability>osgi.extender;filter:="(osgi.extender=org.jahia.bundles.blueprint.extender.config)"</require-capability>
-    <jahia-module-signature>MCwCFECpmRY+jNzm80yPsoYimRUAXL5iAhQ4Y4i7XZDR66PUFYztxwlu25h1Gw==</jahia-module-signature>
+    <jahia-module-signature>MCwCFG1JQ/qpiQHRjcUPDXF/vBX7N5HRAhQY9mbCVESqiiH9SjLvu/YkMUi5Jw==</jahia-module-signature>
   </properties>
   <repositories>
     <repository>

--- a/src/main/java/org/jahia/modules/reports/bean/ReportLockedContent.java
+++ b/src/main/java/org/jahia/modules/reports/bean/ReportLockedContent.java
@@ -86,7 +86,7 @@ public class ReportLockedContent extends QueryReport {
     @Override
     public void execute(JCRSessionWrapper session, int offset, int limit) throws RepositoryException, JSONException {
         String orderStatement = " order by item.[" + resultFields[sortCol] + "] " + order;
-        String pageQueryStr = "SELECT * FROM [jmix:editorialContent] AS item WHERE [jcr:lockOwner] is not null and ISDESCENDANTNODE(item,['" + siteNode.getPath() + "'])" + orderStatement;
+        String pageQueryStr = "SELECT * FROM [jmix:editorialContent] AS item WHERE [j:lockTypes] is not null and ISDESCENDANTNODE(item,['" + siteNode.getPath() + "'])" + orderStatement;
         fillReport(session, pageQueryStr, offset, limit);
         totalContent = getTotalCount(session, pageQueryStr);
     }


### PR DESCRIPTION


## JIRA
https://jira.jahia.org/browse/QA-13997

## Description
Fixed the query for the locked content report, as it was not working with Jahia 8 (https://jira.jahia.org/browse/QA-13983)


## Tests

The following are included in this PR
- [ ] Unit Tests (Most changes _should_ have unit tests)
- [ ] Integration Tests

## Checklist

<!-- 
This section contains a set of non-automated checks, it is there to remind you to think about some business critical topics. 
If some are not applicable they could simply be deleted deleted.
If you need to provide more details, please use the description section.
-->

I have considered the following implications of my change: 

- [ ] Security (in particular for changes to authentication, authorization, data fetching, ...)
- [ ] Performance
- [ ] Migration
- [ ] Code maintainability

## Documentation

<!-- 
Indicate if you have been writing documentation has part of this change.
-->

- [ ] Inline documentation
- [ ] Internal Documentation (wiki)
- [ ] User-facing Documentation
